### PR TITLE
Fix 'Default Condition should be last one' issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,24 +5,24 @@
     "type": "module",
     "exports": {
         "./s": {
-            "default": "./dist/strings/s/index.g.js",
-            "types": "./dist/strings/s/index.g.d.ts"
+            "types": "./dist/strings/s/index.g.d.ts",
+            "default": "./dist/strings/s/index.g.js"
         },
         "./m": {
-            "default": "./dist/strings/m/index.g.js",
-            "types": "./dist/strings/m/index.g.d.ts"
+            "types": "./dist/strings/m/index.g.d.ts",
+            "default": "./dist/strings/m/index.g.js"
         },
         "./l": {
-            "default": "./dist/strings/l/index.g.js",
-            "types": "./dist/strings/l/index.g.d.ts"
+            "types": "./dist/strings/l/index.g.d.ts",
+            "default": "./dist/strings/l/index.g.js"
         },
         "./metadata": {
-            "default": "./dist/metadata/index.js",
-            "types": "./dist/metadata/index.d.ts"
+            "types": "./dist/metadata/index.d.ts",
+            "default": "./dist/metadata/index.js"
         },
         "./react": {
-            "default": "./dist/react/index.js",
-            "types": "./dist/react/index.d.ts"
+            "types": "./dist/react/index.d.ts",
+            "default": "./dist/react/index.js"
         }
     },
     "files": [


### PR DESCRIPTION
When using in a NextJS project, an error kept popping up when trying to import one of the icons:

```
Module not found: Default condition should be last one
```

Did a patch locally with the changes and the error went away.

Fix found here: https://stackoverflow.com/a/76127619/754854

This is one of the weirdest things to complain about from Typescript/NextJS. It says "default" for crying out loud :laughing: 